### PR TITLE
Make package compatible with React 16

### DIFF
--- a/dist/react-drag.js
+++ b/dist/react-drag.js
@@ -4,6 +4,8 @@
 
 var React = (typeof window !== "undefined" ? window['React'] : typeof global !== "undefined" ? global['React'] : null);
 var findDOMNode = (typeof window !== "undefined" ? window['ReactDOM'] : typeof global !== "undefined" ? global['ReactDOM'] : null).findDOMNode;
+var propTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 
 function classNames() {
   var classes = '';
@@ -175,7 +177,7 @@ function removeEvent(el, event, handler) {
   }
 }
 
-var ReactDrag = React.createClass({
+var ReactDrag = createReactClass({
   displayName: 'Draggable',
 
   propTypes: {
@@ -188,7 +190,7 @@ var ReactDrag = React.createClass({
      *
      * Defaults to 'both'.
      */
-    axis: React.PropTypes.oneOf(['both', 'x', 'y']),
+    axis: propTypes.oneOf(['both', 'x', 'y']),
 
     /**
      * `handle` specifies a selector to be used as the handle
@@ -211,7 +213,7 @@ var ReactDrag = React.createClass({
      *   });
      * ```
      */
-    handle: React.PropTypes.string,
+    handle: propTypes.string,
 
     /**
      * `cancel` specifies a selector to be used to prevent drag initialization.
@@ -233,7 +235,7 @@ var ReactDrag = React.createClass({
      *   });
      * ```
      */
-    cancel: React.PropTypes.string,
+    cancel: propTypes.string,
 
     /**
      * `grid` specifies the x and y that dragging should snap to.
@@ -252,7 +254,7 @@ var ReactDrag = React.createClass({
      *   });
      * ```
      */
-    grid: React.PropTypes.arrayOf(React.PropTypes.number),
+    grid: propTypes.arrayOf(propTypes.number),
 
     /**
      * `start` specifies the x and y that the dragged item should start at
@@ -271,7 +273,7 @@ var ReactDrag = React.createClass({
      *   });
      * ```
      */
-    start: React.PropTypes.object,
+    start: propTypes.object,
 
     /**
      * Called when dragging starts.
@@ -291,7 +293,7 @@ var ReactDrag = React.createClass({
      *  }
      * ```
      */
-    onStart: React.PropTypes.func,
+    onStart: propTypes.func,
 
     /**
      * Called while dragging.
@@ -311,7 +313,7 @@ var ReactDrag = React.createClass({
      *  }
      * ```
      */
-    onDrag: React.PropTypes.func,
+    onDrag: propTypes.func,
 
     /**
      * Called when dragging stops.
@@ -331,7 +333,7 @@ var ReactDrag = React.createClass({
      *  }
      * ```
      */
-    onStop: React.PropTypes.func,
+    onStop: propTypes.func,
 
     /**
      * A workaround option which can be passed if
@@ -340,7 +342,7 @@ var ReactDrag = React.createClass({
      * there's internal use of onMouseDown)
      *
      */
-    onMouseDown: React.PropTypes.func,
+    onMouseDown: propTypes.func,
 
     /**
      * Defines the bounderies around the element
@@ -358,7 +360,7 @@ var ReactDrag = React.createClass({
      * The only acceptable string
      * property is: "parent".
      */
-    bound: React.PropTypes.any
+    bound: propTypes.any
   },
 
   componentWillUnmount: function () {
@@ -553,5 +555,5 @@ module.exports = ReactDrag;
 
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}]},{},[1])(1)
+},{"create-react-class":"create-react-class","prop-types":"prop-types"}]},{},[1])(1)
 });

--- a/dist/react-drag.js
+++ b/dist/react-drag.js
@@ -4,8 +4,8 @@
 
 var React = (typeof window !== "undefined" ? window['React'] : typeof global !== "undefined" ? global['React'] : null);
 var findDOMNode = (typeof window !== "undefined" ? window['ReactDOM'] : typeof global !== "undefined" ? global['ReactDOM'] : null).findDOMNode;
-var propTypes = require('prop-types');
-var createReactClass = require('create-react-class');
+var propTypes = (typeof window !== "undefined" ? window['PropTypes'] : typeof global !== "undefined" ? global['PropTypes'] : null);
+var createReactClass = (typeof window !== "undefined" ? window['createReactClass'] : typeof global !== "undefined" ? global['createReactClass'] : null);
 
 function classNames() {
   var classes = '';
@@ -555,5 +555,5 @@ module.exports = ReactDrag;
 
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"create-react-class":"create-react-class","prop-types":"prop-types"}]},{},[1])(1)
+},{}]},{},[1])(1)
 });

--- a/example/index.html
+++ b/example/index.html
@@ -49,11 +49,13 @@
 </head>
 <body>
   <div id="container"></div>
-<script src="../node_modules/react/dist/react-with-addons.js"></script>
-<script src="../node_modules/react-dom/dist/react-dom.js"></script>
-<script src="../dist/react-drag.min.js"></script>
+<script src="../node_modules/react/umd/react.development.js"></script>
+<script src="../node_modules/react-dom/umd/react-dom.development.js"></script>
+<script src="../node_modules/prop-types/prop-types.js"></script>
+<script src="../node_modules/create-react-class/create-react-class.js"></script>
+<script src="../dist/react-drag.js"></script>
 <script>
-var App = React.createClass({
+var App = createReactClass({
   displayName: "App",
 
   getInitialState: function getInitialState() {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,10 +21,16 @@ module.exports = function (config) {
     webpack: {
       cache: true,
       module: {
-        loaders: [
+        rules: [
           {
             test: /\.js$/,
-            loader: 'jsx-loader'
+            exclude: /(node_modules|bower_components)/,
+            use: {
+              loader: 'babel-loader',
+              options: {
+                presets: ['babel-preset-env','react']
+              }
+            }
           }
         ]
       }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function (config) {
     ],
 
     preprocessors: {
-      'specs/main.js': ['webpack']
+      'specs/draggable.spec.js': ['webpack']
     },
 
     webpack: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,7 +8,7 @@ module.exports = function (config) {
     frameworks: ['jasmine'],
 
     files: [
-      'specs/main.js'
+      'specs/draggable.spec.js'
     ],
 
     exclude: [
@@ -48,7 +48,7 @@ module.exports = function (config) {
 
     browsers: ['Chrome'],
 
-    singleRun: false,
+    singleRun: true,
 
     plugins: [
       require('karma-jasmine'),

--- a/lib/react-drag.js
+++ b/lib/react-drag.js
@@ -2,6 +2,8 @@
 
 var React = require('react');
 var findDOMNode = require('react-dom').findDOMNode;
+var propTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 
 function classNames() {
   var classes = '';
@@ -173,7 +175,7 @@ function removeEvent(el, event, handler) {
   }
 }
 
-var ReactDrag = React.createClass({
+var ReactDrag = createReactClass({
   displayName: 'Draggable',
 
   propTypes: {
@@ -186,7 +188,7 @@ var ReactDrag = React.createClass({
      *
      * Defaults to 'both'.
      */
-    axis: React.PropTypes.oneOf(['both', 'x', 'y']),
+    axis: propTypes.oneOf(['both', 'x', 'y']),
 
     /**
      * `handle` specifies a selector to be used as the handle
@@ -209,7 +211,7 @@ var ReactDrag = React.createClass({
      *   });
      * ```
      */
-    handle: React.PropTypes.string,
+    handle: propTypes.string,
 
     /**
      * `cancel` specifies a selector to be used to prevent drag initialization.
@@ -231,7 +233,7 @@ var ReactDrag = React.createClass({
      *   });
      * ```
      */
-    cancel: React.PropTypes.string,
+    cancel: propTypes.string,
 
     /**
      * `grid` specifies the x and y that dragging should snap to.
@@ -250,7 +252,7 @@ var ReactDrag = React.createClass({
      *   });
      * ```
      */
-    grid: React.PropTypes.arrayOf(React.PropTypes.number),
+    grid: propTypes.arrayOf(propTypes.number),
 
     /**
      * `start` specifies the x and y that the dragged item should start at
@@ -269,7 +271,7 @@ var ReactDrag = React.createClass({
      *   });
      * ```
      */
-    start: React.PropTypes.object,
+    start: propTypes.object,
 
     /**
      * Called when dragging starts.
@@ -289,7 +291,7 @@ var ReactDrag = React.createClass({
      *  }
      * ```
      */
-    onStart: React.PropTypes.func,
+    onStart: propTypes.func,
 
     /**
      * Called while dragging.
@@ -309,7 +311,7 @@ var ReactDrag = React.createClass({
      *  }
      * ```
      */
-    onDrag: React.PropTypes.func,
+    onDrag: propTypes.func,
 
     /**
      * Called when dragging stops.
@@ -329,7 +331,7 @@ var ReactDrag = React.createClass({
      *  }
      * ```
      */
-    onStop: React.PropTypes.func,
+    onStop: propTypes.func,
 
     /**
      * A workaround option which can be passed if
@@ -338,7 +340,7 @@ var ReactDrag = React.createClass({
      * there's internal use of onMouseDown)
      *
      */
-    onMouseDown: React.PropTypes.func,
+    onMouseDown: propTypes.func,
 
     /**
      * Defines the bounderies around the element
@@ -356,7 +358,7 @@ var ReactDrag = React.createClass({
      * The only acceptable string
      * property is: "parent".
      */
-    bound: React.PropTypes.any
+    bound: propTypes.any
   },
 
   componentWillUnmount: function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-drag",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "React draggable component",
   "main": "lib/react-drag.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,12 +24,6 @@
     "url": "https://github.com/mgechev/react-drag/issues"
   },
   "homepage": "https://github.com/mgechev/react-drag",
-  "dependencies": {
-    "create-react-class": "^15.6.2",
-    "prop-types": "^15.6.0",
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0"
-  },
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
@@ -44,13 +38,17 @@
     "karma-firefox-launcher": "1.1.0",
     "karma-jasmine": "1.1.1",
     "karma-webpack": "^2.0.9",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "2.0.0",
     "webpack": "^3.10.0"
   },
   "peerDependencies": {
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "create-react-class": "^15.0.0",
+    "prop-types": "^15.0.0",
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
   },
   "browserify": {
     "transform": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "browserify -x react -x react-dom -x prop-types -x create-react-class --standalone ReactDrag ./lib/react-drag.js > ./dist/react-drag.js",
     "minify": "uglifyjs ./dist/react-drag.js --screw-ie8 --compress --mangle --output ./dist/react-drag.min.js",
-    "build_publish": "npm run build && npm run minify"
+    "build_publish": "npm run build && npm run minify",
+    "test": "./node_modules/.bin/karma start ./karma.conf.js"
   },
   "repository": {
     "type": "git",
@@ -30,15 +31,18 @@
     "react-dom": "^15.3.0"
   },
   "devDependencies": {
-    "browserify": "^13.0.0",
+    "browserify": "15.2.0",
     "browserify-shim": "^3.8.11",
-    "karma": "^0.12.19",
-    "karma-chrome-launcher": "^0.1.4",
-    "karma-cli": "0.0.4",
-    "karma-firefox-launcher": "^0.1.3",
-    "karma-jasmine": "^0.1.5",
+    "jasmine-core": "^2.9.1",
+    "karma": "2.0.0",
+    "karma-chrome-launcher": "2.2.0",
+    "karma-cli": "1.0.1",
+    "karma-firefox-launcher": "1.1.0",
+    "karma-jasmine": "1.1.1",
+    "karma-webpack": "^2.0.9",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "2.0.0",
+    "webpack": "^3.10.0"
   },
   "peerDependencies": {
     "react": "^15.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-preset-react": "^6.24.1",
     "browserify": "15.2.0",
     "browserify-shim": "^3.8.11",
+    "create-react-class": "^15.6.2",
     "jasmine-core": "^2.9.1",
     "karma": "2.0.0",
     "karma-chrome-launcher": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
   },
   "browserify-shim": {
     "react": "global:React",
-    "react-dom": "global:ReactDOM"
+    "react-dom": "global:ReactDOM",
+    "prop-types": "global:PropTypes",
+    "create-react-class":  "global:createReactClass"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React draggable component",
   "main": "lib/react-drag.js",
   "scripts": {
-    "build": "browserify -x react -x react-dom --standalone ReactDrag ./lib/react-drag.js > ./dist/react-drag.js",
+    "build": "browserify -x react -x react-dom -x prop-types -x create-react-class --standalone ReactDrag ./lib/react-drag.js > ./dist/react-drag.js",
     "minify": "uglifyjs ./dist/react-drag.js --screw-ie8 --compress --mangle --output ./dist/react-drag.min.js",
     "build_publish": "npm run build && npm run minify"
   },
@@ -24,6 +24,8 @@
   },
   "homepage": "https://github.com/mgechev/react-drag",
   "dependencies": {
+    "create-react-class": "^15.6.2",
+    "prop-types": "^15.6.0",
     "react": "^15.3.0",
     "react-dom": "^15.3.0"
   },
@@ -43,7 +45,9 @@
     "react-dom": "^15.3.0"
   },
   "browserify": {
-    "transform": ["browserify-shim"]
+    "transform": [
+      "browserify-shim"
+    ]
   },
   "browserify-shim": {
     "react": "global:React",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "react-dom": "^15.3.0"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.2",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6.24.1",
     "browserify": "15.2.0",
     "browserify-shim": "^3.8.11",
     "jasmine-core": "^2.9.1",

--- a/specs/draggable.spec.js
+++ b/specs/draggable.spec.js
@@ -1,7 +1,7 @@
-/** @jsx React.DOM */
-var React = require('react/addons');
-var TestUtils = React.addons.TestUtils;
-var Draggable = require('../index');
+var React = require('react');
+var ReactDOM = require('react-dom');
+var TestUtils = require('react-dom/test-utils');
+var Draggable = require('../lib/react-drag');
 
 describe('react-draggable', function () {
   'use strict';
@@ -59,7 +59,7 @@ describe('react-draggable', function () {
         </Draggable>
       );
 
-      TestUtils.Simulate.mouseDown(drag.getDOMNode());
+      TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(drag));
       expect(called).toEqual(true);
     });
 
@@ -71,8 +71,8 @@ describe('react-draggable', function () {
         </Draggable>
       );
 
-      TestUtils.Simulate.mouseDown(drag.getDOMNode());
-      TestUtils.Simulate.mouseUp(drag.getDOMNode());
+      TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(drag));
+      TestUtils.Simulate.mouseUp(ReactDOM.findDOMNode(drag));
       expect(called).toEqual(true);
     });
   });
@@ -81,7 +81,7 @@ describe('react-draggable', function () {
     it('should initialize dragging onmousedown', function () {
       var drag = TestUtils.renderIntoDocument(<Draggable><div/></Draggable>);
 
-      TestUtils.Simulate.mouseDown(drag.getDOMNode());
+      TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(drag));
       expect(drag.state.dragging).toEqual(true);
     });
 
@@ -95,10 +95,10 @@ describe('react-draggable', function () {
         </Draggable>
       );
 
-      TestUtils.Simulate.mouseDown(drag.getDOMNode().querySelector('.content'));
+      TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(drag).querySelector('.content'));
       expect(drag.state.dragging).toEqual(false);
 
-      TestUtils.Simulate.mouseDown(drag.getDOMNode().querySelector('.handle'));
+      TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(drag).querySelector('.handle'));
       expect(drag.state.dragging).toEqual(true);
     });
 
@@ -112,49 +112,31 @@ describe('react-draggable', function () {
         </Draggable>
       );
 
-      TestUtils.Simulate.mouseDown(drag.getDOMNode().querySelector('.cancel'));
+      TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(drag).querySelector('.cancel'));
       expect(drag.state.dragging).toEqual(false);
 
-      TestUtils.Simulate.mouseDown(drag.getDOMNode().querySelector('.content'));
+      TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(drag).querySelector('.content'));
       expect(drag.state.dragging).toEqual(true);
     });
 
     it('should discontinue dragging onmouseup', function () {
       var drag = TestUtils.renderIntoDocument(<Draggable><div/></Draggable>);
 
-      TestUtils.Simulate.mouseDown(drag.getDOMNode());
+      TestUtils.Simulate.mouseDown(ReactDOM.findDOMNode(drag));
       expect(drag.state.dragging).toEqual(true);
 
-      TestUtils.Simulate.mouseUp(drag.getDOMNode());
+      TestUtils.Simulate.mouseUp(ReactDOM.findDOMNode(drag));
       expect(drag.state.dragging).toEqual(false);
     });
   });
 
   describe('validation', function () {
     it('should result with invariant when there isn\'t any children', function () {
-      var drag = (<Draggable/>);
-
-      var error = false;
-      try {
-        TestUtils.renderIntoDocument(drag);
-      } catch (e) {
-        error = true;
-      }
-
-      expect(error).toEqual(true);
+      expect(() => TestUtils.renderIntoDocument(<Draggable/>)).toThrow();
     });
 
     it('should result with invariant if there\'s more than a single child', function () {
-      var drag = (<Draggable><div/><div/></Draggable>);
-
-      var error = false;
-      try {
-        TestUtils.renderIntoDocument(drag);
-      } catch (e) {
-        error = true;
-      }
-
-      expect(error).toEqual(true);
+      expect(() => TestUtils.renderIntoDocument(<Draggable><div/><div/></Draggable>)).toThrow();
     });
   });
 });


### PR DESCRIPTION
In React 16 the use of 'React.propTypes' and 'React.createClass' are
deprecated as these have been moved to new NPM packages 'prop-types' and
'create-react-class' respectively.

This commit updates references to these functions to point to the new
packages and adds the packages to the 'package.json' file.

I have regenerated the 'dist/react-drag.js' file however I'm unable to
regenerate the minified version using UglifyJS under Windows.