### PR TITLE
Transform only in build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React draggable component",
   "main": "lib/react-drag.js",
   "scripts": {
-    "build": "browserify -x react -x react-dom -x prop-types -x create-react-class --standalone ReactDrag ./lib/react-drag.js > ./dist/react-drag.js",
+    "build": "browserify -x react -x react-dom -x prop-types -x create-react-class -t browserify-shim --standalone ReactDrag ./lib/react-drag.js > ./dist/react-drag.js",
     "minify": "uglifyjs ./dist/react-drag.js --screw-ie8 --compress --mangle --output ./dist/react-drag.min.js",
     "build_publish": "npm run build && npm run minify",
     "test": "./node_modules/.bin/karma start ./karma.conf.js"
@@ -50,11 +50,6 @@
     "prop-types": "^15.0.0",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"
-  },
-  "browserify": {
-    "transform": [
-      "browserify-shim"
-    ]
   },
   "browserify-shim": {
     "react": "global:React",


### PR DESCRIPTION
Having the transform in the package.json means it gets executed by anyone using this library if they are unlucky enough to be using browserify as well. Moving it into the build step avoids this issue.