### PR TITLE
Allow supporting React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-drag",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "React draggable component",
   "main": "lib/react-drag.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "karma-firefox-launcher": "1.1.0",
     "karma-jasmine": "1.1.1",
     "karma-webpack": "^2.0.9",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.2.0 || ^17.0.2",
+    "react-dom": "^16.2.0 || ^17.0.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "2.0.0",
     "webpack": "^3.10.0"
@@ -48,8 +48,8 @@
   "peerDependencies": {
     "create-react-class": "^15.0.0",
     "prop-types": "^15.0.0",
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "browserify-shim": {
     "react": "global:React",


### PR DESCRIPTION
Widen the react and react-dom allowed versions, so that downstream consumers can use React 17 without requiring explicit version overrides.